### PR TITLE
fix: fix nil crashing

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -48,6 +48,9 @@ func Contains[T comparable](arr []T, elem T) types.Validate {
 func Or(options ...types.Validate) types.Validate {
 	return func() error {
 		for _, option := range options {
+			if option == nil {
+				continue
+			}
 			if err := option(); err == nil {
 				return nil
 			}
@@ -61,6 +64,9 @@ func Or(options ...types.Validate) types.Validate {
 func And(options ...types.Validate) types.Validate {
 	return func() error {
 		for _, option := range options {
+			if option == nil {
+				continue
+			}
 			if err := option(); err != nil {
 				return err
 			}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -167,6 +167,7 @@ func TestOr(t *testing.T) {
 		"nil options will be skipped": {
 			options: []ttypes.Validate{
 				nil,
+				func() error { return nil },
 			},
 			expectedErr: nil,
 		},
@@ -213,6 +214,7 @@ func TestAnd(t *testing.T) {
 		"nil options will be skipped": {
 			options: []ttypes.Validate{
 				nil,
+				func() error { return nil },
 			},
 			expectedErr: nil,
 		},

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -164,6 +164,12 @@ func TestOr(t *testing.T) {
 			},
 			expectedErr: errs.OrError,
 		},
+		"nil options will be skipped": {
+			options: []ttypes.Validate{
+				nil,
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for testName, testCase := range tests {
@@ -203,6 +209,12 @@ func TestAnd(t *testing.T) {
 				func() error { return errs.InvalidLengthError },
 			},
 			expectedErr: errs.IsNotEmptyErr,
+		},
+		"nil options will be skipped": {
+			options: []ttypes.Validate{
+				nil,
+			},
+			expectedErr: nil,
 		},
 	}
 

--- a/validator/lazy_validator.go
+++ b/validator/lazy_validator.go
@@ -1,10 +1,13 @@
 package validator
 
-import "github.com/Jh123x/go-validate/ttypes"
+import (
+	"github.com/Jh123x/go-validate/options"
+	"github.com/Jh123x/go-validate/ttypes"
+)
 
 // LazyValidator is a validator that lazily evaluates the options provided.
 type LazyValidator struct {
-	options []ttypes.Validate
+	option ttypes.Validate
 }
 
 var _ ttypes.Validator[LazyValidator] = (*LazyValidator)(nil)
@@ -19,20 +22,15 @@ func (l *LazyValidator) WithOptions(opts ...ttypes.Validate) *LazyValidator {
 	if l == nil {
 		return nil
 	}
-	newValidator := *l
-	newValidator.options = append(l.options, opts...)
-	return &newValidator
+	combineOptions := options.And(opts...)
+	l.option = options.And(combineOptions, l.option)
+	return l
 }
 
 // Validate validates the options provided.
 func (l *LazyValidator) Validate() error {
-	if l == nil {
+	if l == nil || l.option == nil {
 		return nil
 	}
-	for _, opt := range l.options {
-		if err := opt(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return l.option()
 }

--- a/validator/lazy_validator.go
+++ b/validator/lazy_validator.go
@@ -1,13 +1,10 @@
 package validator
 
-import (
-	"github.com/Jh123x/go-validate/options"
-	"github.com/Jh123x/go-validate/ttypes"
-)
+import "github.com/Jh123x/go-validate/ttypes"
 
 // LazyValidator is a validator that lazily evaluates the options provided.
 type LazyValidator struct {
-	option ttypes.Validate
+	options []ttypes.Validate
 }
 
 var _ ttypes.Validator[LazyValidator] = (*LazyValidator)(nil)
@@ -22,15 +19,20 @@ func (l *LazyValidator) WithOptions(opts ...ttypes.Validate) *LazyValidator {
 	if l == nil {
 		return nil
 	}
-	combineOptions := options.And(opts...)
-	l.option = options.And(combineOptions, l.option)
-	return l
+	newValidator := *l
+	newValidator.options = append(l.options, opts...)
+	return &newValidator
 }
 
 // Validate validates the options provided.
 func (l *LazyValidator) Validate() error {
-	if l == nil || l.option == nil {
+	if l == nil {
 		return nil
 	}
-	return l.option()
+	for _, opt := range l.options {
+		if err := opt(); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Motivation

- `nil` options will crash for composite rules.

## Implementation

- [x] fix: fix bug where nil options will fail

## Testing

- Current unit tests cover most of the current changes.
- New unit test to cover bug cases

## Related PRs

N/A
